### PR TITLE
Added stop and start event for heart rate monitor

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -3,6 +3,7 @@ import document from "document";
 import { HeartRateSensor } from "heart-rate";
 import { today, goals } from "user-activity"
 import * as util from "../common/utils";
+import { display } from "display";
 
 // Update the clock every minute
 clock.granularity = "seconds";
@@ -64,7 +65,6 @@ hrm.onreading = function() {
     //console.log("Current heart rate: " + reading.heartRate);
     heartRateInformation.innerText = reading.heartRate;  
   });
- 
 }
 
 // Update the clock every tick event
@@ -76,4 +76,10 @@ hrm.start();
 // Don't start with a blank screen
 updateClock();
 
-
+display.onchange = function(event) {
+  if (display.on) {
+    hrm.start();
+  } else {
+    hrm.stop();
+  }
+}


### PR DESCRIPTION
Added listener for the display turning off and on, and then turning the heart rate monitor on or off with the display to save battery.
This will only affect the clock face, and the standard heart rate monitoring for the Fitbit will continue.

I was struggling with the dates on my watch face and I got example code from yours that helped me, so I thought I might share a bit of what I found back :)